### PR TITLE
feat: document dev env for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is `@tacc/core-components`, a React component library (TypeScript/JSX) built with Vite and demoed via Storybook. No backend, database, or Docker required.
+
+### Commands
+
+See `README.md` "Resources > Commands" for the full list. Key commands:
+
+- `npm start` — Storybook dev server on port 9000
+- `npm test` — Vitest unit tests (use `npm test -- --run` for single run)
+- `npm run build` — Vite library build to `dist/`
+- `npm run lint` — ESLint (see caveat below)
+
+### Caveats
+
+- **ESLint is not a project dependency.** The `npm run lint` script calls `eslint .` but `eslint` is not listed in `package.json`. The `.eslintrc.json` config is a stub with no parser or plugins, so linting does not currently function. Install eslint@8 globally (`npm install -g eslint@8`) if needed.
+- **Storybook deps are optional.** Always use `npm install --include=optional` to get Storybook packages; plain `npm install` omits them.
+- **Peer dependencies** (React, Formik, Reactstrap, etc.) are resolved from Storybook's transitive deps during development. They are not installed as direct devDependencies.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview

Documents dev environment for Agents.

## Related

N/A

## Changes

- **added** `AGENTS.md`

## Testing

1.  **`npm install --include=optional`**:\
    ✅ Dependencies installed successfully.
2.  **`npm test -- --run`**:\
    ✅ All tests passed (93 passed, 2 skipped, 1 todo).
3.  **`npm run build`**:\
    ✅ Build succeeded (Vite library build + TypeScript declarations generated).
4.  **`npm run lint`**:\
    ⚠️ ESLint is not a project dependency, and `.eslintrc.json` is a stub (pre-existing repo state).
5.  **`npm start`**:\
    ✅ Storybook dev server started successfully on port 9000.
6.  **Manual Testing**:\
    Verified Storybook UI by navigating to Button and Paginator components, and interacting with controls (e.g., `isLoading` prop on Button).

## Screenshots

https://github.com/user-attachments/assets/6ee5edeb-b04f-4366-87be-3b592e6820d4

| paginator | button |
| - | - |
| ![paginator_component](https://github.com/user-attachments/assets/217d2993-1ba1-4abc-8166-8c52e249ef37) | ![button_loading_controls](https://github.com/user-attachments/assets/ed03960a-386d-4914-9597-c76da3537554) |

---
<p><a href="https://cursor.com/agents/bc-8855a65a-1d76-4f6a-8aee-1f43c5ece872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8855a65a-1d76-4f6a-8aee-1f43c5ece872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->